### PR TITLE
Missing files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    makers_toolbelt (0.2.0)
+    makers_toolbelt (0.2.1)
       commander
       httparty
       octokit
@@ -12,20 +12,20 @@ GEM
   specs:
     addressable (2.3.8)
     byebug (9.0.6)
-    commander (4.3.5)
+    commander (4.4.3)
       highline (~> 1.7.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.0)
     highline (1.7.8)
-    httparty (0.14.0)
+    httparty (0.15.6)
       multi_xml (>= 0.5.2)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    octokit (4.6.0)
+    octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     one_factorization (0.1.1)
     rake (12.0.0)
@@ -43,9 +43,9 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     safe_yaml (1.0.4)
-    sawyer (0.8.0)
+    sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 0.10)
+      faraday (~> 0.8, < 1.0)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -63,4 +63,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/lib/makers_toolbelt/command_line/interface.rb
+++ b/lib/makers_toolbelt/command_line/interface.rb
@@ -1,6 +1,6 @@
 require_relative 'questions/get_uri'
 require_relative 'questions/get_positive_number'
-require './lib/makers_toolbelt'
+require_relative '../../makers_toolbelt'
 
 module MakersToolbelt
   module CommandLine

--- a/lib/makers_toolbelt/command_line/questions/get_uri.rb
+++ b/lib/makers_toolbelt/command_line/questions/get_uri.rb
@@ -1,5 +1,5 @@
 require_relative './question'
-require './lib/makers_toolbelt'
+require_relative '../../../makers_toolbelt'
 
 module MakersToolbelt
   module CommandLine
@@ -19,4 +19,3 @@ module MakersToolbelt
     end
   end
 end
-

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module MakersToolBelt
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/makers_toolbelt.gemspec
+++ b/makers_toolbelt.gemspec
@@ -12,7 +12,13 @@ Gem::Specification.new do |s|
   s.email = ['dan@makersacademy.com']
   s.license = 'MIT'
   s.required_ruby_version = '>= 2.4.1'
-  s.files = Dir['lib/*.rb'] + Dir['lib/makers_toolbelt/*.rb'] + Dir['command_map.yml'] + Dir['lib/makers_toolbelt/command_line/*.rb'] + Dir['lib/makers_toolbelt/command_line/questions/*.rb']
+  s.files = Dir[
+    'command_map.yml',
+    'lib/*.rb',
+    'lib/makers_toolbelt/*.rb',
+    'lib/makers_toolbelt/command_line/*.rb',
+    'lib/makers_toolbelt/command_line/questions/*.rb'
+  ]
 
   s.add_runtime_dependency 'octokit'
   s.add_runtime_dependency 'one_factorization'

--- a/makers_toolbelt.gemspec
+++ b/makers_toolbelt.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.email = ['dan@makersacademy.com']
   s.license = 'MIT'
   s.required_ruby_version = '>= 2.4.1'
+  s.files = Dir['lib/*.rb'] + Dir['lib/makers_toolbelt/*.rb'] + Dir['command_map.yml'] + Dir['lib/makers_toolbelt/command_line/*.rb'] + Dir['lib/makers_toolbelt/command_line/questions/*.rb']
 
   s.add_runtime_dependency 'octokit'
   s.add_runtime_dependency 'one_factorization'


### PR DESCRIPTION
Problem: Missing files.
To reproduce: Download current version: https://rubygems.org/gems/makers_toolbelt/versions/0.2.0
```sh
> gem unpack makers_toolbelt-0.2.0.gem
# => Unpacked gem: '/Users/edward/Downloads/makers_toolbelt-0.2.0'
> ls makers_toolbelt-0.2.0
# => bin
```

[This change](https://github.com/makersacademy/toolbelt/commit/fd45061a7817b523041d4d60a69c22e78f946113#diff-d49f0ac1a1520342b9dcc7b907100674) removed the gemspec list of files which I think is needed when `gem build <gemspec>` is run.

http://guides.rubygems.org/specification-reference/#files
http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/

Feel free to improve the changes! It builds the gem and installs properly now with all files.