### PR TITLE
Add a dummy entry when a odd-numbered-length list of IDs is passed to…

### DIFF
--- a/lib/makers_toolbelt/generate_pairs.rb
+++ b/lib/makers_toolbelt/generate_pairs.rb
@@ -17,8 +17,15 @@ class GeneratePairs
   def run
     names = GeneratePairs.load_names(source)
     File.open(path, 'w') do |file|
+      
+      if names.count.odd?
+        names << 'Flying solo' # Will pair a lone person up with a dummy 'flying solo' message
+      end
+      
+      pairs = names.one_factorize.shuffle.to_json
+      
+      file.write pairs
       puts "Pair assignments created in file #{path}"
-      file.write names.one_factorize.shuffle.to_json
     end
   end
 


### PR DESCRIPTION
… generate_pairs

When an odd number of IDs was passed to generate_pairs, it would cause an error (OneFactorization::InvalidLengthError). So, we now ensure the list that is one_factorized is always even, by adding a dummy 'Flying solo' list member, so that the odd person out is matched with 'flying solo' and nothing breaks.